### PR TITLE
Python3 fix for example import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='xkcdpass',
-    version='1.0.1',
+    version='1.0.2',
     author='Steven Tobin',
     author_email='steventtobin@gmail.com',
     url='https://github.com/redacted/XKCD-password-generator',

--- a/xkcdpass/example_import.py
+++ b/xkcdpass/example_import.py
@@ -5,4 +5,4 @@ from xkcd_password import generate_wordlist, generate_xkcdpassword
 mywords = generate_wordlist(wordfile='3esl.txt', min_length=5, max_length=8,)
 
 # create a password with the acrostic 'face'
-print generate_xkcdpassword(mywords, acrostic="face")
+print(generate_xkcdpassword(mywords, acrostic="face"))


### PR DESCRIPTION
Because of a print statement in the example, the module will not install
cleanly on Python3.

Also bamp version.
