### PR TITLE
Updated Python 3 version check to use sys.version_info

### DIFF
--- a/xkcdpass/xkcd_password.py
+++ b/xkcdpass/xkcd_password.py
@@ -56,7 +56,7 @@ except AttributeError:
     rng = random.Random
 
 # Python 3 compatibility
-if sys.version[0] == "3":
+if sys.version_info[0] >= 3:
     raw_input = input
 
 


### PR DESCRIPTION
The string `sys.version` should not be used for version checks as there are no guarantees regarding its contents. Instead `sys.version_info` should be used.