### PR TITLE
Use locate_wordfile if no wordfile given.

### DIFF
--- a/xkcdpass/xkcd_password.py
+++ b/xkcdpass/xkcd_password.py
@@ -104,6 +104,9 @@ def generate_wordlist(wordfile=None,
     Generate a word list from either a kwarg wordfile, or a system default
     valid_chars is a regular expression match condition (default - all chars)
     """
+                      
+    if wordfile is None:
+        wordfile = locate_wordfile()
 
     words = []
 


### PR DESCRIPTION
Noticed that the docstring suggests wordfile is optional, but no code to support that option. Was an easy fix. Thank you for your consideration!