### PR TITLE
add location of cracklib-small on Debian

### DIFF
--- a/xkcdpass/xkcd_password.py
+++ b/xkcdpass/xkcd_password.py
@@ -87,6 +87,7 @@ def locate_wordfile():
         'static',
         'default.txt')
     common_word_files = ["/usr/share/cracklib/cracklib-small",
+                         "/usr/share/dict/cracklib-small",
                          static_default,
                          "/usr/dict/words",
                          "/usr/share/dict/words"]


### PR DESCRIPTION
The Debian cracklib-runtime package installs cracklib-small to /usr/share/dict/cracklib-small