### PR TITLE
Use tox to test against all supported environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+dist: xenial
+sudo: false
+language: python
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
+cache: pip
+
+script:
+  - tox
+
+install:
+  - pip install tox tox-travis

--- a/README.rst
+++ b/README.rst
@@ -185,6 +185,27 @@ or setting the appropriate environment variable::
     export XKCDPASS_ALLOW_WEAKRNG=1
 
 
+Contributing
+============
+
+Python 2.7 users need an extra dependency for tests::
+
+    $ pip install -e '.[test]'
+
+Tests can be run against your current environment using::
+
+    $ python -m unittest
+
+To run the test suite against all available environments, install `tox
+<https://pypi.python.org/pypi/tox>`_::
+
+    $ pip install tox
+
+Run the tests with::
+
+    $ tox
+
+
 Changelog
 =========
 - **1.17.0** Add French, Norwegian, and Portuguese dictionaries. Bugfixes and improvements to tests (WIP).

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
+import sys
 from setuptools import setup
 import sys
+
+PYTHON2 = sys.version_info < (3,)
 
 setup(
     name='xkcdpass',
@@ -10,6 +13,9 @@ setup(
     description='Generate secure multiword passwords/passphrases, inspired by XKCD',
     long_description=open('README.rst').read(),
     packages=['xkcdpass'],
+    extras_require={
+        'test': ['mock'] if PYTHON2 else [],
+    },
     zip_safe=False,
     license='BSD',
     include_package_data=True,

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py27,py34,py35,py36,py37
+
+[testenv]
+# Remove discover when dropping support for Python 2.
+commands = python -m unittest discover
+
+[testenv:py27]
+deps = mock
+setenv = PYTHONHASHSEED=0


### PR DESCRIPTION
Supported environments depends on the Python version installed on the developers' machine. Tox will automatically detect the available python versions and run the tests against them.

Using tox makes it easier to configure continuous integration (such as [travis-ci](https://travis-ci.org/) which is free for open-source projects and has a [documentation for python projects](https://docs.travis-ci.com/user/languages/python/)).