### PR TITLE
 Add argument to specify password line ending: --separator

### DIFF
--- a/examples/example_import.py
+++ b/examples/example_import.py
@@ -1,5 +1,6 @@
-import xkcdpass.xkcd_password as xp
 import random
+
+import xkcdpass.xkcd_password as xp
 
 
 def random_capitalisation(s, chance):

--- a/examples/example_json.py
+++ b/examples/example_json.py
@@ -1,4 +1,5 @@
 from xkcdpass import xkcd_password as xp
+
 from django.http import JsonResponse
 
 

--- a/examples/example_postprocess.py
+++ b/examples/example_postprocess.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
-import sys
 import fileinput
 import random
+import sys
 
 # generate a list of symbols via ascii code
 SYMBOLS = [str(unichr(i)) for i in range(33, 65)]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from setuptools import setup
 
-
 setup(
     name='xkcdpass',
     version='1.14.3',

--- a/tests/test_xkcdpass.py
+++ b/tests/test_xkcdpass.py
@@ -1,10 +1,9 @@
 import re
-import sys
 import subprocess
+import sys
 import unittest
 
 from xkcdpass import xkcd_password
-
 
 WORDFILE = 'xkcdpass/static/legacy'
 

--- a/tests/test_xkcdpass.py
+++ b/tests/test_xkcdpass.py
@@ -47,6 +47,24 @@ class XkcdPasswordTests(unittest.TestCase):
             delimiter=tdelim)
         self.assertIsNotNone(re.match('([a-z]+(_|$))+', result))
 
+    def test_separator(self):
+        count = 3
+        result = subprocess.check_output(
+            ["python", "xkcdpass/xkcd_password.py",
+             "--count", str(count),
+             "--delimiter", "|",
+             "--separator", " "])
+        self.assertEqual(result.count(b" "), 3)
+
+    def test_separator_no_end(self):
+        "Pipe output to other program. e.g. `xkcdpass -c 1 -s "" | xsel -b`"
+        count = 1
+        result = subprocess.check_output(
+            ["python", "xkcdpass/xkcd_password.py",
+             "--count", str(count),
+             "--separator", ""])
+        self.assertEqual(result.find(b"\n"), -1)
+
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(XkcdPasswordTests)

--- a/xkcdpass/xkcd_password.py
+++ b/xkcdpass/xkcd_password.py
@@ -112,7 +112,7 @@ def generate_wordlist(wordfile=None,
     Generate a word list from either a kwarg wordfile, or a system default
     valid_chars is a regular expression match condition (default - all chars)
     """
-    
+
     # deal with inconsistent min and max, erring toward security
     if min_length > max_length:
         max_length = min_length

--- a/xkcdpass/xkcd_password.py
+++ b/xkcdpass/xkcd_password.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
+from __future__ import print_function
+
 import argparse
 import math
 import os
@@ -291,12 +293,15 @@ def emit_passwords(wordlist, options):
     """ Generate the specified number of passwords and output them. """
     count = options.count
     while count > 0:
-        print(generate_xkcdpassword(
-            wordlist,
-            interactive=options.interactive,
-            numwords=options.numwords,
-            acrostic=options.acrostic,
-            delimiter=options.delimiter))
+        print(
+            generate_xkcdpassword(
+                wordlist,
+                interactive=options.interactive,
+                numwords=options.numwords,
+                acrostic=options.acrostic,
+                delimiter=options.delimiter
+            ),
+            end=options.separator)
         count -= 1
 
 
@@ -358,6 +363,10 @@ class XkcdPassArgumentParser(argparse.ArgumentParser):
             "-d", "--delimiter",
             dest="delimiter", default=" ", metavar="DELIM",
             help="Separate words within a passphrase with DELIM.")
+        self.add_argument(
+            "-s", "--separator",
+            dest="separator", default="\n", metavar="SEP",
+            help="Separate generated passphrases with SEP.")
         self.add_argument(
             "--allow-weak-rng",
             action="store_true", dest="allow_weak_rng", default=False,

--- a/xkcdpass/xkcd_password.py
+++ b/xkcdpass/xkcd_password.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import random
+import argparse
+import math
 import os
 import os.path
-import argparse
+import random
 import re
-import math
 import sys
 
 __LICENSE__ = """


### PR DESCRIPTION
Adds a new separator argument used to separate passwords in the output.
This is useful when piping the output of xkcdpass to another command,
e.g. copying a password to the clipboard on Linux with:

```
xkcdpass --count 1 --numwords 10 --separator "" | xsel -b
```