### PR TITLE
Andresmweber bugfix/issue83 entropy info

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup
+import sys
 
 setup(
     name='xkcdpass',
@@ -17,6 +18,8 @@ setup(
             'xkcdpass = xkcdpass.xkcd_password:main',
         ],
     },
+    tests_require=['mock'] if sys.version_info[0] == 2 else None,
+    test_suite = 'tests',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python :: 2',

--- a/tests/test_xkcdpass.py
+++ b/tests/test_xkcdpass.py
@@ -1,6 +1,6 @@
 """ Unit test for `xkcd_password` module. """
 
-import subprocess
+from subprocess import PIPE, Popen
 import argparse
 import io
 import re
@@ -83,12 +83,8 @@ class XkcdPasswordTests(unittest.TestCase):
             testing=True
         )
 
-        self.assertTrue(
-            observed_random_result_1 in (
-                expected_random_result_1_py2, expected_random_result_1_py3))
-        self.assertTrue(
-            observed_random_result_2 in (
-                expected_random_result_2_py2, expected_random_result_2_py3))
+        self.assertIn(observed_random_result_1, (expected_random_result_1_py2, expected_random_result_1_py3))
+        self.assertIn(observed_random_result_2, (expected_random_result_2_py2, expected_random_result_2_py3))
 
 
 class TestEmitPasswords(unittest.TestCase):
@@ -157,18 +153,16 @@ class TestEntropyInformation(unittest.TestCase):
     """ Test cases for function `emit_passwords`. """
 
     @staticmethod
-    def run_xkcdpass_process():
-        test = subprocess.Popen(
-            ["xkcdpass", "-V", "-i"], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
-        return test.communicate()[0]
+    def run_xkcdpass_process(*args):
+        process = Popen(["xkcdpass", "-V", "-i"], stdout=PIPE, stdin=PIPE)
+        return process.communicate('\n'.join(args))[0]
 
-    @mock.patch('__builtin__.input', side_effect=['4', 'y'])
-    def test_entropy_printout_valid_input(self, mock):
-        values = self.run_xkcdpass_process()
-        self.assertIn(
-            'A 4 word password from this list will have roughly 51', values)
+    def test_entropy_printout_valid_input(self):
+        values = self.run_xkcdpass_process('4', 'y')
+        self.assertIn('A 4 word password from this list will have roughly 51', values)
 
 
 if __name__ == '__main__':
-    suites = [unittest.TestLoader().loadTestsFromTestCase(test_case) for test_case in [XkcdPasswordTests, TestEmitPasswords, TestEntropyInformation]]
+    test_cases = [XkcdPasswordTests, TestEmitPasswords, TestEntropyInformation]
+    suites = [unittest.TestLoader().loadTestsFromTestCase(test_case) for test_case in test_cases]
     unittest.TextTestRunner(verbosity=2).run(unittest.TestSuite(suites))

--- a/tests/test_xkcdpass.py
+++ b/tests/test_xkcdpass.py
@@ -1,5 +1,6 @@
 """ Unit test for `xkcd_password` module. """
 
+import subprocess
 import argparse
 import io
 import re
@@ -77,7 +78,7 @@ class XkcdPasswordTests(unittest.TestCase):
         words_extra = "this is a test also".lower().split()
         observed_random_result_1 = results["random"]
         observed_random_result_2 = xkcd_password.set_case(
-            words_extra, 
+            words_extra,
             method="random",
             testing=True
         )
@@ -90,7 +91,7 @@ class XkcdPasswordTests(unittest.TestCase):
                 expected_random_result_2_py2, expected_random_result_2_py3))
 
 
-class emit_passwords_TestCase(unittest.TestCase):
+class TestEmitPasswords(unittest.TestCase):
     """ Test cases for function `emit_passwords`. """
 
     def setUp(self):
@@ -152,6 +153,22 @@ class emit_passwords_TestCase(unittest.TestCase):
         self.assertEqual(output.find(unwanted_separator), -1)
 
 
+class TestEntropyInformation(unittest.TestCase):
+    """ Test cases for function `emit_passwords`. """
+
+    @staticmethod
+    def run_xkcdpass_process():
+        test = subprocess.Popen(
+            ["xkcdpass", "-V", "-i"], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+        return test.communicate()[0]
+
+    @mock.patch('__builtin__.input', side_effect=['4', 'y'])
+    def test_entropy_printout_valid_input(self, mock):
+        values = self.run_xkcdpass_process()
+        self.assertIn(
+            'A 4 word password from this list will have roughly 51', values)
+
+
 if __name__ == '__main__':
-    suite = unittest.TestLoader().loadTestsFromTestCase(XkcdPasswordTests)
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    suites = [unittest.TestLoader().loadTestsFromTestCase(test_case) for test_case in [XkcdPasswordTests, TestEmitPasswords, TestEntropyInformation]]
+    unittest.TextTestRunner(verbosity=2).run(unittest.TestSuite(suites))

--- a/xkcdpass/xkcd_password.py
+++ b/xkcdpass/xkcd_password.py
@@ -328,45 +328,46 @@ def generate_xkcdpassword(wordlist,
     # useful if driving the logic from other code
     if not interactive:
         return gen_passwd()
-
+        
     # else, interactive session
-    # define input validators
-    def n_words_validator(answer):
-        """
-        Validate custom number of words input
-        """
-
-        if isinstance(answer, str) and len(answer) == 0:
-            return numwords
-        try:
-            number = int(answer)
-            if number < 1:
-                raise ValueError
-            return number
-        except ValueError:
-            sys.stderr.write("Please enter a positive integer\n")
-            sys.exit(1)
-
-    def accepted_validator(answer):
-        return answer.lower().strip() in ["y", "yes"]
-
-    if not acrostic:
-        n_words_prompt = ("Enter number of words (default {0}):"
-                          " ".format(numwords))
-
-        numwords = try_input(n_words_prompt, n_words_validator)
     else:
-        numwords = len(acrostic)
+        # define input validators
+        def accepted_validator(answer):
+            return answer.lower().strip() in ["y", "yes"]
 
-    # generate passwords until the user accepts
-    accepted = False
+        # generate passwords until the user accepts
+        accepted = False
+        
+        while not accepted:
+            passwd = gen_passwd()
+            print("Generated: " + passwd)
+            accepted = try_input("Accept? [yN] ", accepted_validator)
+            print('accepted', accepted)
+        return passwd
+        
 
-    while not accepted:
-        passwd = gen_passwd()
-        print("Generated: " + passwd)
-        accepted = try_input("Accept? [yN] ", accepted_validator)
+def initialize_interactive_run(options):
+    def n_words_validator(answer):
+            """
+            Validate custom number of words input
+            """
+            
+            if isinstance(answer, str) and len(answer) == 0:
+                return options.numwords
+            try:
+                number = int(answer)
+                if number < 1:
+                    raise ValueError
+                return number
+            except ValueError:
+                sys.stderr.write("Please enter a positive integer\n")
+                sys.exit(1)
 
-    return passwd
+    if not options.acrostic:
+        n_words_prompt = ("Enter number of words (default {0}):\n".format(options.numwords))
+        options.numwords = try_input(n_words_prompt, n_words_validator)
+    else:
+        options.numwords = len(options.acrostic)
 
 
 def emit_passwords(wordlist, options):
@@ -489,6 +490,9 @@ def main(argv=None):
             max_length=options.max_length,
             valid_chars=options.valid_chars)
 
+        if options.interactive:
+            initialize_interactive_run(options)
+        
         if options.verbose:
             verbose_reports(my_wordlist, options)
 


### PR DESCRIPTION
This addresses #83 and modifies the tests.

It corrects the placement of the logic block for setting `options.numwords` **before** the verbose printout.  There is a test case added as well using subprocess to test via the CLI with the interactive flag on.  The TestCases were all added to the test_xkcdpass.py entry point.

Also there were edits to setup.py to make it simpler to run the test suite using `python setup.py test`.  I also refactored the TestCase name for emit_passwords_TestCase to TestEmitPasswords to conform to [PEP-8 ](https://www.python.org/dev/peps/pep-0008/#class-names)