### PR TITLE
Drop support for Python 3.2 and 3.3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Contributions welcome and gratefully appreciated!
 Requirements
 ============
 
-Python 2 (version 2.7 or later), or Python 3 (version 3.2 or later). Running module unit tests on Python 2 requires ``mock`` to be installed.
+Python 2 (version 2.7 or later), or Python 3 (version 3.4 or later). Running module unit tests on Python 2 requires ``mock`` to be installed.
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Python 3.3.7's end-of-life was September 2017.
https://www.python.org/downloads/release/python-337/