### PR TITLE
Fix --min and --max description in man page

### DIFF
--- a/xkcdpass.1
+++ b/xkcdpass.1
@@ -64,14 +64,14 @@ eff-short, eff-special, legacy
 \f[B]\-\-min\f[] MIN_LENGTH
 .RS
 .PP
-Generate passphrases containing at least MIN_LENGTH words.
+Generate passphrases containing at least MIN_LENGTH letters.
 (Default: 5)
 .RE
 .PP
 \f[B]\-\-max\f[] MAX_LENGTH
 .RS
 .PP
-Generate passphrases containing at most MAX_LENGTH words.
+Generate passphrases containing at most MAX_LENGTH letters.
 (Default: 9)
 .RE
 .PP


### PR DESCRIPTION
Both options said to specify number of _words_, but they actually specify number of _letters_.
