### PR TITLE
Add French and Portuguese dict in help message

### DIFF
--- a/xkcdpass/xkcd_password.py
+++ b/xkcdpass/xkcd_password.py
@@ -412,8 +412,10 @@ class XkcdPassArgumentParser(argparse.ArgumentParser):
                 "Specify that the file WORDFILE contains the list"
                 " of valid words from which to generate passphrases."
                 " Provided wordfiles: eff-long (default), eff-short,"
-                " eff-special, legacy, spa-mich (Spanish), fin-kotus (Finnish)"
-                " ita-wiki (Italian), ger-anlx (German), nor-nb (Norwegian)"))
+                " eff-special, legacy, spa-mich (Spanish), fin-kotus (Finnish),"
+                " ita-wiki (Italian), ger-anlx (German), nor-nb (Norwegian),"
+                " fr-freelang (French), pt-ipublicis (Portuguese),"
+                " pt-l33t-ipublicis (Portuguese)"))
         self.add_argument(
             "--min",
             dest="min_length", type=int, default=5, metavar="MIN_LENGTH",


### PR DESCRIPTION
The documentation was not up to date with the actual list of dictionaries. I did not included `fr-freelang-bernard-vivier`, `pt-pt-ipublicis`, and `pt-pt-l33t-ipublicis` because they are exact copies of other dictionaries (no idea why).