### PR TITLE
Add randomized delimiters

### DIFF
--- a/tests/test_xkcdpass.py
+++ b/tests/test_xkcdpass.py
@@ -103,6 +103,8 @@ class TestEmitPasswords(unittest.TestCase):
             acrostic=False,
             delimiter=" ",
             separator=u"\n",
+            valid_delimiters="",
+            random_delimiters=False,
             case='lower',
         )
 


### PR DESCRIPTION
This allows xkcdpass to generate passwords that meet the "strong
password" requirements of many websites, without losing the memorizable
nature of the word list, a la the xkcd comic.

At least if you know symbol pronunciations like "bang" for !

I know you did this in your example post processing, but I think it's nice to just build into the default command line tool.

If you agree, I'll fix the tests and add any new ones that make sense.