### PR TITLE
setup.py: exclude examples as well

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     description='Generate secure multiword passwords/passphrases, inspired by XKCD',
     long_description=open('README.rst', encoding='utf-8').read(),
     #packages=['xkcdpass'],
-    packages=find_namespace_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
+    packages=find_namespace_packages(exclude=["examples", "*.tests", "*.tests.*", "tests.*", "tests"]),
     zip_safe=False,
     license='BSD',
     include_package_data=True,


### PR DESCRIPTION
After commit f1abf9d, the examples dir is getting installed to site-packages.  Let's add it to the exclude list in setup.py.