### PR TITLE
Fix non-deterministic test

### DIFF
--- a/tests/test_xkcdpass.py
+++ b/tests/test_xkcdpass.py
@@ -51,8 +51,9 @@ class XkcdPasswordTests(unittest.TestCase):
     def test_random_delimiter(self):
         wordlist = xkcd_password.generate_wordlist(WORDFILE, min_length=3, max_length=3)
         result = xkcd_password.generate_xkcdpassword(wordlist, numwords=3, random_delimiters=True)
+        answer = len(result)
 
-        self.assertEqual(11, len(result))
+        self.assertTrue(answer == 11 or answer == 10 or answer == 9)
 
     def test_set_case(self):
         words = "this is only a GREAT Test".lower().split()


### PR DESCRIPTION
Hello!

During another [ZHF](https://github.com/NixOS/nixpkgs/issues/265948), I've discovered a regression in build of this software project at Nix's bulding farm (called Hydra): https://hydra.nixos.org/build/240490554

The build fails due to a little non-determinism in `test_random_delimiter` test function. If `generate_xkcdpassword()` function does not take delimiter characters, it chooses them from default list, which contains empty string.

So, the value of `len(result)` could be not only 11, but also 10 or 9. This quick fix tries to solve the problem.

It would be nice to upstream those changes, so package definition would no more use a patch, as it does right now:

https://github.com/NixOS/nixpkgs/pull/268540/files#diff-96aa19f6bba1d17c2894d4fad12b1bbd5657796fcfed8812464380883c2fd0b5R23