### PR TITLE
improve descirption for --min and --max

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,9 +87,9 @@ A concise overview of the available ``xkcdpass`` options can be accessed via::
                                     fr-freelang (French), pt-ipublicis / pt-l33t-ipublicis (Portuguese)
                                     swe-short (Swedish)
         --min=MIN_LENGTH
-                                    Minimum length of words to make password
+                                    Minimum number of letters required in words used to make password
         --max=MAX_LENGTH
-                                    Maximum length of words to make password
+                                    Maximum number of letters allowed in words used to make password
         -n NUMWORDS, --numwords=NUMWORDS
                                     Number of words to make password
         -i, --interactive

--- a/xkcdpass.1
+++ b/xkcdpass.1
@@ -37,14 +37,14 @@ which to generate passphrases.
 \f[B]\-\-min\f[] MIN_LENGTH
 .RS
 .PP
-Generate passphrases containing at least MIN_LENGTH letters.
+Minimum number of letters required in words used to make password.
 (Default: 5)
 .RE
 .PP
 \f[B]\-\-max\f[] MAX_LENGTH
 .RS
 .PP
-Generate passphrases containing at most MAX_LENGTH letters.
+Maximum number of letters allowed in words used to make password.
 (Default: 9)
 .RE
 .PP


### PR DESCRIPTION
At least for a non-native speaker the descriptions in the Readme and man-page where both still ambiguous/wrong. In addition they were not consistent.