### PR TITLE
fix no delimiter being used sometimes

### DIFF
--- a/xkcdpass/xkcd_password.py
+++ b/xkcdpass/xkcd_password.py
@@ -422,7 +422,7 @@ def emit_passwords(wordlist, options):
     """ Generate the specified number of passwords and output them. """
     count = options.count
     if options.valid_delimiters:
-        valid_delimiters = list(options.valid_delimiters) + [""]
+        valid_delimiters = list(options.valid_delimiters)
     else:
         valid_delimiters = DEFAULT_DELIMITERS
     while count > 0:


### PR DESCRIPTION
The command `xkcdpass --random-delimiters --valid-delimiters=...` sometimes would output words using the empty string as as delimiter. This commit makes it so that when --valid-delimiters is passed, only the delimiters specified are used, without adding an empty string in addition to those.

Closes #165.